### PR TITLE
Fix issues in the instructions around the PaymentSaga

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Implement the process as follows:
 
   Store the bike ID as process state (simply a member field, which will be used later).
 
-  Associated the payment reference with the saga instance using:
+  Associated the rental reference with the saga instance using, as this will be need to correlate the payment event later:
 
         SagaLifecycle.associateWith("paymentReference", event.rentalReference());
 

--- a/README.md
+++ b/README.md
@@ -208,12 +208,12 @@ Implement the process as follows:
   Send a `PreparePaymentCommand` via the `CommandGateway`. THe handler for this command is implemented in the Payment
   Application.
 
-  * Annotate a member function that accepts a `PaymentConfirmedEvent` with
+* Annotate a member function that accepts a `PaymentConfirmedEvent` with
 
-          @EndSaga
-          @SagaEventHandler(associationProperty = "paymentReference")
+        @EndSaga
+        @SagaEventHandler(associationProperty = "paymentReference")
 
-    Send a `ApproveRequestCommand`.
+  Send a `ApproveRequestCommand`.
 
 > Why can't the `@EndSaga` event handler be associated with `bikeId`?
 

--- a/README.md
+++ b/README.md
@@ -195,25 +195,25 @@ Implement the process as follows:
 * Annotate a member function that accepts a `BikeRequestedEvent` with
 
         @StartSaga
-        @SagaEventHandler(associationId = "bikeId")
+        @SagaEventHandler(associationProperty = "bikeId")
 
 * In this event handler:
 
   Store the bike ID as process state (simply a member field, which will be used later).
 
-  Generate a new payment ID (for example using `UUID.randomUUID.toString()`) and associated it with the process via:
+  Associated the payment reference with the saga instance using:
 
-        SagaLifecycle.associatedWith("paymentId", paymentId)
+        SagaLifecycle.associateWith("paymentReference", event.rentalReference());
 
   Send a `PreparePaymentCommand` via the `CommandGateway`. THe handler for this command is implemented in the Payment
   Application.
 
-* Annotate a member function that accepts a `PaymentConfirmedEvent` with
+  * Annotate a member function that accepts a `PaymentConfirmedEvent` with
 
-        @EndSaga
-        @SagaEventHandler(associationId = "paymentId")
+          @EndSaga
+          @SagaEventHandler(associationProperty = "paymentReference")
 
-  Send a `ApproveBikeRequestCommand`.
+    Send a `ApproveRequestCommand`.
 
 > Why can't the `@EndSaga` event handler be associated with `bikeId`?
 

--- a/README.md
+++ b/README.md
@@ -201,10 +201,10 @@ Implement the process as follows:
 
   Store the bike ID as process state (simply a member field, which will be used later).
 
-  Associated the rental reference with the saga instance using, as this will be need to correlate the payment event later:
+  Associated the rental reference with the saga instance as follows:
 
         SagaLifecycle.associateWith("paymentReference", event.rentalReference());
-
+  
   Send a `PreparePaymentCommand` via the `CommandGateway`. THe handler for this command is implemented in the Payment
   Application.
 


### PR DESCRIPTION
I was doing the workshop and noticed that the instructions were a bit out of date with the latest version of the framework. Also the associated property has to be the paymentreference as the payment system will generate the paymentId so you can't know it ahead of time.